### PR TITLE
fix: DLQ purge API 406 Not Acceptable 오류 수정

### DIFF
--- a/src/main/java/com/emailagent/service/admin/RabbitMQManagementService.java
+++ b/src/main/java/com/emailagent/service/admin/RabbitMQManagementService.java
@@ -125,6 +125,7 @@ public class RabbitMQManagementService {
                 .encodeToString((username + ":" + password).getBytes());
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Basic " + credentials);
+        headers.set("Accept", "*/*");
         return headers;
     }
 


### PR DESCRIPTION
- buildAuthHeaders()에 Accept: */* 헤더 추가
- RabbitMQ Management API DELETE 요청 시 기본 Accept 헤더로 인한 406 오류 해결